### PR TITLE
Ignore Rules Handled by Prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,14 +17,8 @@ module.exports = {
     "error-reason": ["error", { "errorMessageMaxLength": 250 }],
 
     "no-empty-blocks": "warning",
-    "indentation": ["error", 4],
-    "whitespace": "warning",
     "deprecated-suicide": "warning",
     "pragma-on-top": "error",
-    "function-whitespace": "error",
-    "semicolon-whitespace": "error",
-    "comma-whitespace": "error",
-    "operator-whitespace": "off",
     "emit": "error",
     "no-constant": "warning",
     "max-len": "error",
@@ -38,8 +32,16 @@ module.exports = {
     "blank-lines": "off",
     "arg-overflow": "off",
     "function-order": "error",
-    "conditionals-whitespace": "off",
     "no-experimental": "error",
-    "no-trailing-whitespace": "warning"
+
+    // Handled by prettier
+    "indentation": ["off"],
+    "conditionals-whitespace": "off",
+    "whitespace": "off",
+    "function-whitespace": "off",
+    "semicolon-whitespace": "off",
+    "comma-whitespace": "off",
+    "operator-whitespace": "off",
+    "no-trailing-whitespace": "off"
   },
 };


### PR DESCRIPTION
Since we run `solium` in conjunction with `prettier`, like in https://github.com/keep-network/tbtc/blob/master/solidity/package.json#L24, we want to disable the solium style rules that conflict with the prettier style rules.

Tagging @Shadowfiend for review